### PR TITLE
Nosslverify

### DIFF
--- a/filehub/client.py
+++ b/filehub/client.py
@@ -352,7 +352,7 @@ class EventWriter(object):
 
         if not self.client.verify:
             try:
-                ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+                ctx = ssl.SSLContext()
             except AttributeError:
                 raise AssertionError('SSL verification cannot be disabled')
             ctx.verify_mode = ssl.CERT_NONE


### PR DESCRIPTION
Handle the environment variable to disable SSL verification. This works for both old and new python, although verification can only be disabled for new python where `ssl.SSLContext` exists.