### PR TITLE
Fix for bypassing SSL validation errors. 

### DIFF
--- a/veristack/__main__.py
+++ b/veristack/__main__.py
@@ -288,7 +288,7 @@ def main(opt):
         -t --token=TOKEN    OAuth2 Token
         -f --token-file=FILE  The file in which to read/write the token.
         -H --host HOST      Host to connect to [default: localhost]
-        -p --port PORT      TCP port to connect to on HOST [default: 41666]
+        -p --port PORT      TCP port to connect to on HOST [default: 41677]
         -c --count COUNT    Number of messages to generate/send [default: 0]
         -s --sleep SLEEP    Seconds to sleep between messages [default: 0]
         -o --connections=CONNECTIONS    Number of clients to send messages

--- a/veristack/__main__.py
+++ b/veristack/__main__.py
@@ -288,7 +288,7 @@ def main(opt):
         -t --token=TOKEN    OAuth2 Token
         -f --token-file=FILE  The file in which to read/write the token.
         -H --host HOST      Host to connect to [default: localhost]
-        -p --port PORT      TCP port to connect to on HOST [default: 41677]
+        -p --port PORT      TCP port to connect to on HOST [default: 41666]
         -c --count COUNT    Number of messages to generate/send [default: 0]
         -s --sleep SLEEP    Seconds to sleep between messages [default: 0]
         -o --connections=CONNECTIONS    Number of clients to send messages

--- a/veristack/client.py
+++ b/veristack/client.py
@@ -432,10 +432,11 @@ class Client(_OAuth2Session):
         self.uid = kwargs.pop('uid')
         self.refresh_token_callback = kwargs.pop('refresh_token_callback',
                                                  None)
-        self.verify = kwargs.pop('verify', True)
+        self.kwargverify = kwargs.pop('verify', True)
         super(Client, self).__init__(
             *args[2:], client=JWTApplicationClient(kwargs['client_id']),
             **kwargs)
+        self.verify = self.kwargverify
         # Set this after the super() call, as our superclass's superclass sets
         # this indiscriminately to True.
         if not self.verify:

--- a/veristack/client.py
+++ b/veristack/client.py
@@ -423,7 +423,7 @@ class EventWriter(object):
 class Client(_OAuth2Session):
     """Client for communicating to Veristack."""
 
-    def __init__(self, verify=True, *args, **kwargs):
+    def __init__(self, *args, verify=True, **kwargs):
         """Instantiate Client."""
         self.client_secret = kwargs.pop('client_secret', None)
         if self.client_secret is None and 'token' not in kwargs:

--- a/veristack/client.py
+++ b/veristack/client.py
@@ -423,7 +423,7 @@ class EventWriter(object):
 class Client(_OAuth2Session):
     """Client for communicating to Veristack."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, verify=True, *args, **kwargs):
         """Instantiate Client."""
         self.client_secret = kwargs.pop('client_secret', None)
         if self.client_secret is None and 'token' not in kwargs:
@@ -432,11 +432,10 @@ class Client(_OAuth2Session):
         self.uid = kwargs.pop('uid')
         self.refresh_token_callback = kwargs.pop('refresh_token_callback',
                                                  None)
-        self.kwargverify = kwargs.pop('verify', True)
         super(Client, self).__init__(
             *args[2:], client=JWTApplicationClient(kwargs['client_id']),
             **kwargs)
-        self.verify = self.kwargverify
+        self.verify = verify
         # Set this after the super() call, as our superclass's superclass sets
         # this indiscriminately to True.
         if not self.verify:


### PR DESCRIPTION
https://github.com/requests/requests/blob/master/requests/sessions.py#L373

That line overrides our kwargs.pop. We need to re-override it after the super().